### PR TITLE
Compiling fails on Arch Linux (LibNFS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,39 @@
 This QEMU patch introduces irix/solaris userland emulation. It currently runs
 only under linux and macOS (though BSD support would probably be feasable).
 
-### compiling
+### Compiling for Linux
 
 Configure QEMU for irix/solaris userland emulation for linux and compile (see the original
 QEMU README for further instructions):
 
 ```sh
-./configure
-    --prefix=/usr
-    --sysconfdir=/etc
-    --localstatedir=/var
-    --libexecdir=/usr/lib/qemu
-    --audio-drv-list=
-    --disable-bluez
-    --disable-sdl
-    --disable-gtk
-    --disable-vte
-    --disable-opengl
-    --disable-virglrenderer
-    --disable-blobs
-    --disable-tools
-    --disable-guest-agent
-    --target-list=irix-linux-user,irixn32-linux-user,irix64-linux-user,solaris-linux-user
-    --disable-capstone
-    --disable-debug-info
-    --disable-werror
+$ ./configure --prefix=/usr \
+    --sysconfdir=/etc \
+    --localstatedir=/var \
+    --libexecdir=/usr/lib/qemu \
+    --audio-drv-list= \
+    --disable-bluez \
+    --disable-sdl \
+    --disable-gtk \
+    --disable-vte \
+    --disable-opengl \
+    --disable-virglrenderer \
+    --disable-blobs \
+    --disable-tools \
+    --disable-guest-agent \
+    --target-list=irix-linux-user,irixn32-linux-user,irix64-linux-user,solaris-linux-user \
+    --disable-capstone \
+    --disable-debug-info \
+    --disable-werror \
     --extra-cflags="-fmacro-prefix-map=${srcdir}=."
+$ make && sudo make install
 ```
+#### Note:
+You may want to remove conflicting docs and binaries that *may* conflict with QEMU in the following directories: `usr/lib` and `usr/share`
 
-Or, configure QEMU for irix userland emulation for macOS
-
+### Compiling for macOS
 ```sh
-./configure --target-list=irix-darwin-user \
+$ ./configure --target-list=irix-darwin-user \
     --disable-werror \
     --disable-vnc \
     --disable-sdl \
@@ -43,7 +44,7 @@ Or, configure QEMU for irix userland emulation for macOS
     --disable-hax \
     --disable-hvf \
     --disable-tools
-make && make install
+$ make && make install
 ```
 
 Note: macOS 11 Big Sur and above no longer supports building qemu-irix during failure workflows

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ $ ./configure --prefix=/usr \
     --target-list=irix-linux-user,irixn32-linux-user,irix64-linux-user,solaris-linux-user \
     --disable-capstone \
     --disable-debug-info \
-    --disable-werror \
-    --extra-cflags="-fmacro-prefix-map=${srcdir}=."
+    --disable-werror
 $ make && sudo make install
 ```
 #### Note:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,26 @@ Configure QEMU for irix/solaris userland emulation for linux and compile (see th
 QEMU README for further instructions):
 
 ```sh
-configure --target-list=irix-linux-user,irixn32-linux-user,irix64-linux-user,solaris-linux-user --disable-werror
-make && make install
+./configure
+    --prefix=/usr
+    --sysconfdir=/etc
+    --localstatedir=/var
+    --libexecdir=/usr/lib/qemu
+    --audio-drv-list=
+    --disable-bluez
+    --disable-sdl
+    --disable-gtk
+    --disable-vte
+    --disable-opengl
+    --disable-virglrenderer
+    --disable-blobs
+    --disable-tools
+    --disable-guest-agent
+    --target-list=irix-linux-user,irixn32-linux-user,irix64-linux-user,solaris-linux-user
+    --disable-capstone
+    --disable-debug-info
+    --disable-werror
+    --extra-cflags="-fmacro-prefix-map=${srcdir}=."
 ```
 
 Or, configure QEMU for irix userland emulation for macOS

--- a/bug
+++ b/bug
@@ -1,1 +1,0 @@
-This file will be removed after the issue has been resolved.

--- a/bug
+++ b/bug
@@ -1,0 +1,1 @@
+This file will be removed after the issue has been resolved.


### PR DESCRIPTION
Here's the error log:
```
block/nfs.c: In function ‘nfs_co_preadv’:
block/nfs.c:274:25: error: passing argument 3 of ‘nfs_pread_async’ makes pointer from integer without a cast [-Wint-conversion]
  274 |                         offset, bytes, nfs_co_generic_cb, &task) != 0) {
      |                         ^~~~~~
      |                         |
      |                         uint64_t {aka long unsigned int}
In file included from block/nfs.c:43:
/usr/include/nfsc/libnfs.h:723:34: note: expected ‘void *’ but argument is of type ‘uint64_t’ {aka ‘long unsigned int’}
  723 |                            void *buf, size_t count, uint64_t offset,
      |                            ~~~~~~^~~
block/nfs.c:274:40: error: passing argument 5 of ‘nfs_pread_async’ makes integer from pointer without a cast [-Wint-conversion]
  274 |                         offset, bytes, nfs_co_generic_cb, &task) != 0) {
      |                                        ^~~~~~~~~~~~~~~~~
      |                                        |
      |                                        void (*)(int,  struct nfs_context *, void *, void *)
/usr/include/nfsc/libnfs.h:723:62: note: expected ‘uint64_t’ {aka ‘long unsigned int’} but argument is of type ‘void (*)(int,  struct nfs_context *, void *, void *)’
  723 |                            void *buf, size_t count, uint64_t offset,
      |                                                     ~~~~~~~~~^~~~~~
block/nfs.c:274:59: error: passing argument 6 of ‘nfs_pread_async’ from incompatible pointer type [-Wincompatible-pointer-types]
  274 |                         offset, bytes, nfs_co_generic_cb, &task) != 0) {
      |                                                           ^~~~~
      |                                                           |
      |                                                           NFSRPC *
/usr/include/nfsc/libnfs.h:724:35: note: expected ‘nfs_cb’ {aka ‘void (*)(int,  struct nfs_context *, void *, void *)’} but argument is of type ‘NFSRPC *’
  724 |                            nfs_cb cb, void *private_data);
      |                            ~~~~~~~^~
block/nfs.c:273:9: error: too few arguments to function ‘nfs_pread_async’
  273 |     if (nfs_pread_async(client->context, client->fh,
      |         ^~~~~~~~~~~~~~~
/usr/include/nfsc/libnfs.h:722:12: note: declared here
  722 | EXTERN int nfs_pread_async(struct nfs_context *nfs, struct nfsfh *nfsfh,
      |            ^~~~~~~~~~~~~~~
block/nfs.c: In function ‘nfs_co_pwritev’:
block/nfs.c:321:26: error: passing argument 3 of ‘nfs_pwrite_async’ makes pointer from integer without a cast [-Wint-conversion]
  321 |                          offset, bytes, buf,
      |                          ^~~~~~
      |                          |
      |                          uint64_t {aka long unsigned int}
/usr/include/nfsc/libnfs.h:785:41: note: expected ‘const void *’ but argument is of type ‘uint64_t’ {aka ‘long unsigned int’}
  785 |                             const void *buf, size_t count, uint64_t offset,
      |                             ~~~~~~~~~~~~^~~
block/nfs.c:321:41: error: passing argument 5 of ‘nfs_pwrite_async’ makes integer from pointer without a cast [-Wint-conversion]
  321 |                          offset, bytes, buf,
      |                                         ^~~
      |                                         |
      |                                         char *
/usr/include/nfsc/libnfs.h:785:69: note: expected ‘uint64_t’ {aka ‘long unsigned int’} but argument is of type ‘char *’
  785 |                             const void *buf, size_t count, uint64_t offset,
      |                                                            ~~~~~~~~~^~~~~~
make: *** [/home/arch/gitclones/qemu-irix/rules.mak:66: block/nfs.o] Error 1
```

Configured with the same options as given in [README.md](https://github.com/AlexN-SM64/qemu-irix/blob/master/README.md)
`configure` output:
```
Install prefix    /usr/local
BIOS directory    /usr/local/share/qemu
firmware path     /usr/local/share/qemu-firmware
binary directory  /usr/local/bin
library directory /usr/local/lib
module directory  /usr/local/lib/qemu
libexec directory /usr/local/libexec
include directory /usr/local/include
config directory  /usr/local/etc
local state directory   /usr/local/var
Manual directory  /usr/local/share/man
ELF interp prefix /usr/gnemul/qemu-%M
Source path       /home/arch/gitclones/qemu-irix
GIT binary        git
GIT submodules    ui/keycodemapdb
C compiler        cc
Host C compiler   cc
C++ compiler      c++
Objective-C compiler clang
ARFLAGS           rv
CFLAGS            -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -g 
QEMU_CFLAGS       -I/usr/include/pixman-1  -DHAS_LIBSSH2_SFTP_FSYNC -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-6 -pthread -fPIE -DPIE -m64 -mcx16 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wstrict-prototypes -Wredundant-decls -Wall -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -fwrapv  -Wexpansion-to-defined -Wendif-labels -Wno-shift-negative-value -Wno-missing-include-dirs -Wempty-body -Wnested-externs -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wold-style-declaration -Wold-style-definition -Wtype-limits -fstack-protector-strong -I/usr/include/p11-kit-1    -I/usr/include/libpng16 -DWITH_GZFILEOP -I/usr/include/libdrm -I/usr/include/spice-server -I/usr/include/spice-1 -I/usr/include/pixman-1 -I/usr/include/opus -I/usr/include/cacard -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-6 -pthread -I/usr/include/nss -I/usr/include/nspr -I/usr/include/PCSC -DWITH_GZFILEOP -I/usr/include/capstone
LDFLAGS           -Wl,--warn-common -Wl,-z,relro -Wl,-z,now -pie -m64 -g 
make              make
install           install
python            python -B
smbd              /usr/sbin/smbd
module support    no
host CPU          x86_64
host big endian   no
target list       irix-linux-user irixn32-linux-user irix64-linux-user solaris-linux-user
gprof enabled     no
sparse enabled    no
strip binaries    yes
profiler          no
static build      no
SDL support       yes (2.32.54)
GTK support       yes (3.24.49)
GTK GL support    yes
VTE support       yes (0.80.1)
TLS priority      NORMAL
GNUTLS support    yes
GNUTLS rnd        yes
libgcrypt         no
libgcrypt kdf     no
nettle            yes (3.10.1)
nettle kdf        yes
libtasn1          yes
curses support    yes
virgl support     yes
curl support      yes
mingw32 support   no
Audio drivers     oss
Block whitelist (rw) 
Block whitelist (ro) 
VirtFS support    
Multipath support 
VNC support       yes
VNC SASL support  yes
VNC JPEG support  yes
VNC PNG support   yes
xen support       no
brlapi support    yes
bluez  support    yes
Documentation     yes
PIE               yes
vde support       yes
netmap support    no
Linux AIO support yes
ATTR/XATTR support yes
Install blobs     yes
KVM support       yes
HAX support       no
HVF support       no
WHPX support      no
TCG support       yes
TCG debug enabled no
TCG interpreter   no
malloc trim support yes
RDMA support      no
fdt support       yes
preadv support    yes
fdatasync         yes
madvise           yes
posix_madvise     yes
posix_memalign    yes
libcap-ng support yes
vhost-net support yes
vhost-crypto support yes
vhost-scsi support yes
vhost-vsock support yes
vhost-user support yes
Trace backends    log
spice support     yes (0.14.4/0.15.2)
rbd support       no
xfsctl support    yes
smartcard support yes
libusb            yes
usb net redir     yes
OpenGL support    yes
OpenGL dmabufs    yes
libiscsi support  yes
libnfs support    yes
build guest agent yes
QGA VSS support   no
QGA w32 disk info no
QGA MSI support   no
seccomp support   yes
coroutine backend ucontext
coroutine pool    yes
debug stack usage no
crypto afalg      no
GlusterFS support yes
gcov              gcov
gcov enabled      no
TPM support       yes
libssh2 support   yes
TPM passthrough   yes
TPM emulator      yes
QOM debugging     yes
Live block migration yes
lzo support       yes
snappy support    yes
bzip2 support     yes
NUMA host support yes
libxml2           yes
```

I don't know if I'm dumb or what but it could also be a dependency problem,
or I believe a pragmaticand/or parameters problems.